### PR TITLE
Fix NVD API vulnerability fetching

### DIFF
--- a/Fetch/Fetch_NVD_Vul.py
+++ b/Fetch/Fetch_NVD_Vul.py
@@ -64,7 +64,11 @@ def fetch_cves(keyword):
     api_key = os.getenv("NVD_API_KEY")
     url = "https://services.nvd.nist.gov/rest/json/cves/2.0"
     params = {"keywordSearch": keyword, "resultsPerPage": 10}
-    headers = {"apiKey": api_key, "User-Agent": "StreamlitCVEFetcher/1.0"}
+    headers = {"User-Agent": "StreamlitCVEFetcher/1.0"}
+    
+    # Only add API key if it's not empty
+    if api_key and api_key.strip():
+        headers["apiKey"] = api_key
 
     print(f"Fetching CVEs for keyword: {keyword}")
     try:


### PR DESCRIPTION
## Summary

This PR fixes the NVD API vulnerability fetching issue that was causing 'Could not retrieve vulnerabilities from any source' errors.

## Changes

- **Fixed NVD API authentication**: Only include the `apiKey` header when `NVD_API_KEY` is not empty or whitespace
- **Prevents invalid API key errors**: The NVD API was returning 'Invalid apiKey' errors when an empty key was sent
- **Maintains backward compatibility**: The API works without authentication for basic usage

## Technical Details

The issue was in `Fetch/Fetch_NVD_Vul.py` where the code was always sending an `apiKey` header even when the `NVD_API_KEY` environment variable was empty. The NVD API interprets an empty API key as invalid and returns a 404 error.

## Testing

- ✅ NVD API now works without API key
- ✅ No more 'Invalid apiKey' errors
- ✅ Vulnerability fetching works in both demo and live modes
- ✅ Backward compatible with existing API key usage

## Related Issues

Fixes the 'Could not retrieve vulnerabilities from any source' error reported by users.